### PR TITLE
Larger softmax value

### DIFF
--- a/training_config/multilang_dependency_parser.jsonnet
+++ b/training_config/multilang_dependency_parser.jsonnet
@@ -64,9 +64,9 @@
                     "do_layer_norm": false,
                     "dropout": 0.3,
                     "scalar_mix_parameters": [
-                        -9e20,
+                        -9e10,
                         1,
-                        -9e20
+                        -9e10
                     ],
                     "options_files": {
                         "en": "https://www.dropbox.com/s/ypjuzlf7kj957g3/options262.json?dl=1",


### PR DESCRIPTION
The previous one caused overflow sometimes. e-10 is good enough